### PR TITLE
Fix facet css - the checked box for the last filter activated turns blue, contrast is too low with the background

### DIFF
--- a/ckanext/csa/public/GCWeb/css/theme.min.css
+++ b/ckanext/csa/public/GCWeb/css/theme.min.css
@@ -1296,6 +1296,10 @@ td, th {
   content: "\e260"
 }
 
+.fa-check-square-o::before {
+	color: white;
+}
+
 *, :after, :before {
   -webkit-box-sizing: border-box;
   box-sizing: border-box


### PR DESCRIPTION
Fix ensures it stays white - high contrast. 