### PR TITLE
[#164] Bulk Editing

### DIFF
--- a/ckanext/csa/fanstatic/extra.css
+++ b/ckanext/csa/fanstatic/extra.css
@@ -44,3 +44,19 @@
             background: #fff;
           }
         }
+
+/***
+ * "Corrections" for CKAN extensions and the GCWeb theme.
+ ***/
+
+.accordion-item h2 {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.bulk-manager .update-to-fields .update-field-item .btn {
+    flex-basis: unset !important;
+}
+.bulk-manager .filters-list .filter-item .btn {
+    flex-basis: unset !important;
+}

--- a/ckanext/csa/plugin.py
+++ b/ckanext/csa/plugin.py
@@ -1,14 +1,14 @@
-from typing import Union
-
-import ckan.plugins as p
-import ckan.plugins.toolkit as tk
 import json
 import os
 import inspect
+from typing import Union
 
+from flask import Blueprint
+import ckan.plugins as p
+import ckan.plugins.toolkit as tk
 from ckan.lib.plugins import DefaultTranslation
 from ckan.plugins.toolkit import _, request
-from flask import Blueprint
+from ckanext.bulk.interfaces import IBulk
 
 from ckanext.csa import helpers, loader, validators
 
@@ -21,6 +21,7 @@ class CsaPlugin(p.SingletonPlugin, DefaultTranslation):
     p.implements(p.ITranslation)
     p.implements(p.IBlueprint)
     p.implements(p.IValidators)
+    p.implements(IBulk, inherit=True)
 
     _field_descriptions = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -e git+https://github.com/ckan/ckanext-fluent.git#egg=ckanext-fluent
 -e git+https://github.com/ckan/ckan.git@2.11#egg=ckan
 -e git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming
+-e git+https://github.com/DataShades/ckanext-bulk.git#egg=ckanext-bulk


### PR DESCRIPTION
Depends on the changes in #161.

Adds support for bulk dataset updates and deletion using ckanext-bulk.

![image](https://github.com/user-attachments/assets/17018633-5560-45d0-9264-8728de793fe5)

Gotchas:

- Search does not understand multi-value search fields (those whose values are lists like [0, 1, 2])
- Search isn't very user friendly with multiselect fields whose values aren't the same as the labels. For example, the `Geographic Region Name` field may be set to  `Canada`, which is 0 in the search index, or `Atlantic` which is `1` in the search index. A user would expect to be able to search for  `Canada` or `Atlantic` but instead must search for `0` or `1`.

If desired @nfee006 we could take a couple of days to improve `ckanext-bulk` (and contribute these changes upstream) to work better with `ckanext-scheming`'s schemas to resolve the above gotchas. This would allow users to just select `Canada` from a dropdown for `Geographic Region Name` by reflecting the schema.